### PR TITLE
fix next key not looping back to the beginning

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -947,7 +947,7 @@ _ebpf_core_protocol_map_get_next_key(
 
     // If the pervious key was not found, return the first key (if it wasn't already looked up).
     if (retval == EBPF_KEY_NOT_FOUND) {
-        assert(previous_key_length == 0);
+        ebpf_assert(previous_key_length != 0);
         retval = ebpf_map_next_key(map, next_key_length, NULL, reply->next_key);
     }
 

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -945,6 +945,11 @@ _ebpf_core_protocol_map_get_next_key(
     retval = ebpf_map_next_key(
         map, next_key_length, previous_key_length == 0 ? NULL : request->previous_key, reply->next_key);
 
+    // If the next key was not found, return the first key (if it wasn't already looked up).
+    if (retval == EBPF_NO_MORE_KEYS && previous_key_length != 0) {
+        retval = ebpf_map_next_key(map, next_key_length, NULL, reply->next_key);
+    }
+
     reply->header.length = reply_length;
 
 Done:

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -945,8 +945,9 @@ _ebpf_core_protocol_map_get_next_key(
     retval = ebpf_map_next_key(
         map, next_key_length, previous_key_length == 0 ? NULL : request->previous_key, reply->next_key);
 
-    // If the next key was not found, return the first key (if it wasn't already looked up).
-    if (retval == EBPF_NO_MORE_KEYS && previous_key_length != 0) {
+    // If the pervious key was not found, return the first key (if it wasn't already looked up).
+    if (retval == EBPF_KEY_NOT_FOUND) {
+        assert(previous_key_length == 0);
         retval = ebpf_map_next_key(map, next_key_length, NULL, reply->next_key);
     }
 

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -813,6 +813,13 @@ ebpf_hash_table_next_key_pointer_and_value(
                 found_entry = true;
             }
         }
+
+        // If there was a previous key that was not present in the bucket, then it is not present in the hash table
+        // either.
+        if (!found_entry && previous_key != NULL) {
+            result = EBPF_KEY_NOT_FOUND;
+        }
+
         if (next_entry) {
             break;
         }

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -818,6 +818,7 @@ ebpf_hash_table_next_key_pointer_and_value(
         // either.
         if (!found_entry && previous_key != NULL) {
             result = EBPF_KEY_NOT_FOUND;
+            goto Done;
         }
 
         if (next_entry) {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -742,11 +742,14 @@ bindmonitor_test(ebpf_execution_type_t execution_type)
 
     uint64_t pid;
     REQUIRE(bpf_map_get_next_key(process_map_fd, NULL, &pid) == 0);
+    uint64_t init_pid = pid;
     REQUIRE(pid != 0);
     REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) == 0);
     REQUIRE(pid != 0);
-    REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) < 0);
-    REQUIRE(errno == ENOENT);
+    // REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) < 0);
+    // REQUIRE(errno == ENOENT);
+    REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) == 0);
+    REQUIRE(init_pid == pid);
 
     hook.detach_and_close_link(&link);
 
@@ -860,11 +863,14 @@ bindmonitor_tailcall_test(ebpf_execution_type_t execution_type)
 
     uint64_t pid;
     REQUIRE(bpf_map_get_next_key(process_map_fd, NULL, &pid) == 0);
+    uint64_t init_pid = pid;
     REQUIRE(pid != 0);
     REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) == 0);
     REQUIRE(pid != 0);
-    REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) < 0);
-    REQUIRE(errno == ENOENT);
+    // REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) < 0);
+    // REQUIRE(errno == ENOENT);
+    REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) == 0);
+    REQUIRE(init_pid == pid);
 
     hook.detach_and_close_link(&link);
 

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -742,14 +742,11 @@ bindmonitor_test(ebpf_execution_type_t execution_type)
 
     uint64_t pid;
     REQUIRE(bpf_map_get_next_key(process_map_fd, NULL, &pid) == 0);
-    uint64_t init_pid = pid;
     REQUIRE(pid != 0);
     REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) == 0);
     REQUIRE(pid != 0);
-    // REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) < 0);
-    // REQUIRE(errno == ENOENT);
-    REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) == 0);
-    REQUIRE(init_pid == pid);
+    REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) < 0);
+    REQUIRE(errno == ENOENT);
 
     hook.detach_and_close_link(&link);
 
@@ -863,14 +860,11 @@ bindmonitor_tailcall_test(ebpf_execution_type_t execution_type)
 
     uint64_t pid;
     REQUIRE(bpf_map_get_next_key(process_map_fd, NULL, &pid) == 0);
-    uint64_t init_pid = pid;
     REQUIRE(pid != 0);
     REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) == 0);
     REQUIRE(pid != 0);
-    // REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) < 0);
-    // REQUIRE(errno == ENOENT);
-    REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) == 0);
-    REQUIRE(init_pid == pid);
+    REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) < 0);
+    REQUIRE(errno == ENOENT);
 
     hook.detach_and_close_link(&link);
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2712,8 +2712,9 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     attr.map_fd = map_fd;
     attr.key = (uintptr_t)&key;
     attr.next_key = (uintptr_t)&next_key;
-    REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) < 0);
+    // REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) < 0);
     // REQUIRE(errno == ENOENT);
+    REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
     REQUIRE(attr.key == init_key);
     REQUIRE(attr.value == init_value);
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2713,7 +2713,7 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     attr.key = (uintptr_t)&key;
     attr.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) < 0);
-    //REQUIRE(errno == ENOENT);
+    // REQUIRE(errno == ENOENT);
     REQUIRE(attr.key == init_key);
     REQUIRE(attr.value == init_value)
 
@@ -3048,7 +3048,7 @@ TEST_CASE("bind_tail_call_max_exceed", "[libbpf]")
     // REQUIRE(bpf_map_get_next_key(map_fd, &key, &key) < 0);
     // REQUIRE(errno == ENOENT);
     // Querying beyond the last key will loopback to the first key.
-    REQUIRE(bpf_map_get_next_key(map_fd, &key, &key) ==0 0);
+    REQUIRE(bpf_map_get_next_key(map_fd, &key, &key) == 0 0);
     REQUIRE(key == first_key);
     REQUIRE(val == first_val)
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2715,7 +2715,7 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) < 0);
     // REQUIRE(errno == ENOENT);
     REQUIRE(attr.key == init_key);
-    REQUIRE(attr.value == init_value)
+    REQUIRE(attr.value == init_value);
 
     // Delete the entry.
     memset(&attr, 0, sizeof(attr));
@@ -3048,7 +3048,7 @@ TEST_CASE("bind_tail_call_max_exceed", "[libbpf]")
     // REQUIRE(bpf_map_get_next_key(map_fd, &key, &key) < 0);
     // REQUIRE(errno == ENOENT);
     // Querying beyond the last key will loopback to the first key.
-    REQUIRE(bpf_map_get_next_key(map_fd, &key, &key) == 0 0);
+    REQUIRE(bpf_map_get_next_key(map_fd, &key, &key) == 0);
     REQUIRE(key == first_key);
     REQUIRE(val == first_val)
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2672,14 +2672,14 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     attr.map_type = BPF_MAP_TYPE_HASH;
     attr.key_size = sizeof(uint32_t);
     attr.value_size = sizeof(uint32_t);
-    attr.max_entries = 2;
+    attr.max_entries = 3;
     attr.map_flags = 0;
     int map_fd = bpf(BPF_MAP_CREATE, &attr, sizeof(attr));
     REQUIRE(map_fd > 0);
 
     // Add an entry.
-    uint32_t key = 42;
     uint64_t value = 12345;
+    uint32_t key = 42;
     memset(&attr, 0, sizeof(attr));
     attr.map_fd = map_fd;
     attr.key = (uintptr_t)&key;
@@ -2746,7 +2746,7 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     // Test that the bpf_map_get_next_key returns the first vey of the BPF map if the previous key is not found.
     // Add 3 entries entry.
     for (key = 100; key < 400; key += 100) {
-        value = key * 1000;
+        value = (uint64_t)key * 1000;
         memset(&attr, 0, sizeof(attr));
         attr.map_fd = map_fd;
         attr.key = (uintptr_t)&key;
@@ -2761,7 +2761,7 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     attr.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
     REQUIRE(value == attr.key * 1000);
-    // ...then ask for a key that is not present, and check that the first key is returned.
+    // ...then lookup a key that is not present, and check that the first key is returned.
     memset(&attr, 0, sizeof(attr));
     attr.map_fd = map_fd;
     attr.key = 400;

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2744,34 +2744,29 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     REQUIRE(errno == ENOENT);
 
     // Test that the bpf_map_get_next_key returns the first key of the BPF map if the previous key is not found.
-    // Add 3 entries entry.
+    // Add 3 entries into the now empty map.
     for (key = 100; key < 400; key += 100) {
-        value = (uint64_t)key * 10;
         memset(&attr, 0, sizeof(attr));
         attr.map_fd = map_fd;
         attr.key = (uintptr_t)&key;
-        attr.value = (uintptr_t)&value;
         REQUIRE(bpf(BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr)) == 0);
     }
-    // Lookup the first key in the map, so to check it later.
+    // Lookup the first key in the map, so to check it's returned later.
     value = 0;
     memset(&attr, 0, sizeof(attr));
     attr.map_fd = map_fd;
     attr.key = NULL;
-    attr.value = (uintptr_t)&value;
     attr.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
     uint64_t first_key = next_key;
-    // ...then lookup a key that is not present, and check that the first key is returned.
-    key = 400;
-    value = 0;
+    // Lookup a key that is not present in the map, and check that the first key is returned.
+    key = 123;
     memset(&attr, 0, sizeof(attr));
     attr.map_fd = map_fd;
     attr.key = (uintptr_t)&key;
-    attr.value = (uintptr_t)&value;
     attr.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
-    REQUIRE(next_key == first_key); // Check it returned the first key.
+    REQUIRE(next_key == first_key);
 
     Platform::_close(map_fd);
 }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2743,31 +2743,30 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) < 0);
     REQUIRE(errno == ENOENT);
 
-    // Test that the bpf_map_get_next_key returns the first vey of the BPF map if the previous key is not found.
-    // Add 3 entries entry.
-    for (key = 100; key < 400; key += 100) {
-        value = (uint64_t)key * 1000;
-        memset(&attr, 0, sizeof(attr));
-        attr.map_fd = map_fd;
-        attr.key = (uintptr_t)&key;
-        attr.value = (uintptr_t)&value;
-        attr.flags = 0;
-        REQUIRE(bpf(BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr)) == 0);
-    }
-    // Start looping from the first key...
-    memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = 100;
-    attr.next_key = (uintptr_t)&next_key;
-    REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
-    REQUIRE(value == attr.key * 1000);
-    // ...then lookup a key that is not present, and check that the first key is returned.
-    memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = 400;
-    attr.next_key = (uintptr_t)&next_key;
-    REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
-    REQUIRE(value == 100 * 1000); // Check it returned the first key.
+    // // Test that the bpf_map_get_next_key returns the first key of the BPF map if the previous key is not found.
+    // // Add 3 entries entry.
+    // for (key = 100; key < 400; key += 100) {
+    //     value = (uint64_t)key * 10;
+    //     memset(&attr, 0, sizeof(attr));
+    //     attr.map_fd = map_fd;
+    //     attr.key = (uintptr_t)&key;
+    //     attr.value = (uintptr_t)&value;
+    //     REQUIRE(bpf(BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr)) == 0);
+    // }
+    // // Start looping from the first key...
+    // memset(&attr, 0, sizeof(attr));
+    // attr.map_fd = map_fd;
+    // attr.key = 100;
+    // attr.next_key = (uintptr_t)&next_key;
+    // REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
+    // REQUIRE(value == attr.key * 10);
+    // // ...then lookup a key that is not present, and check that the first key is returned.
+    // memset(&attr, 0, sizeof(attr));
+    // attr.map_fd = map_fd;
+    // attr.key = 400;
+    // attr.next_key = (uintptr_t)&next_key;
+    // REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
+    // REQUIRE(value == 100 * 10); // Check it returned the first key.
 
     Platform::_close(map_fd);
 }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -3050,7 +3050,7 @@ TEST_CASE("bind_tail_call_max_exceed", "[libbpf]")
     // Querying beyond the last key will loopback to the first key.
     REQUIRE(bpf_map_get_next_key(map_fd, &key, &key) == 0);
     REQUIRE(key == first_key);
-    REQUIRE(val == first_val)
+    REQUIRE(val == first_val);
 
     // Create a hook for the bind program.
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2754,14 +2754,14 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
         REQUIRE(bpf(BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr)) == 0);
     }
     // Start looping from the first key...
-    key = 100;
-    value = 0;
-    memset(&attr, 0, sizeof(attr));
-    attr.map_fd = map_fd;
-    attr.key = (uintptr_t)&key;
-    attr.value = (uintptr_t)&value;
-    REQUIRE(bpf(BPF_MAP_LOOKUP_ELEM, &attr, sizeof(attr)) == 0);
-    REQUIRE(value == attr.key * 10);
+    // key = 100;
+    // value = 0;
+    // memset(&attr, 0, sizeof(attr));
+    // attr.map_fd = map_fd;
+    // attr.key = (uintptr_t)&key;
+    // attr.value = (uintptr_t)&value;
+    // REQUIRE(bpf(BPF_MAP_LOOKUP_ELEM, &attr, sizeof(attr)) == 0);
+    // REQUIRE(value == attr.key * 10);
     // ...then lookup a key that is not present, and check that the first key is returned.
     key = 400;
     value = 0;
@@ -2771,7 +2771,7 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     attr.value = (uintptr_t)&value;
     attr.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
-    REQUIRE(value == 100 * 10); // Check it returned the first key.
+    REQUIRE(next_key == 100); // Check it returned the first key.
 
     Platform::_close(map_fd);
 }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2753,15 +2753,14 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
         attr.value = (uintptr_t)&value;
         REQUIRE(bpf(BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr)) == 0);
     }
-    // Start looping from the first key...
-    // key = 100;
-    // value = 0;
-    // memset(&attr, 0, sizeof(attr));
-    // attr.map_fd = map_fd;
-    // attr.key = (uintptr_t)&key;
-    // attr.value = (uintptr_t)&value;
-    // REQUIRE(bpf(BPF_MAP_LOOKUP_ELEM, &attr, sizeof(attr)) == 0);
-    // REQUIRE(value == attr.key * 10);
+    // Lookup the first key in the map, so to check it later.
+    value = 0;
+    memset(&attr, 0, sizeof(attr));
+    attr.map_fd = map_fd;
+    attr.key = NULL;
+    attr.value = (uintptr_t)&value;
+    REQUIRE(bpf(BPF_MAP_LOOKUP_ELEM, &attr, sizeof(attr)) == 0);
+    uint64_t first_key = attr.next_key;
     // ...then lookup a key that is not present, and check that the first key is returned.
     key = 400;
     value = 0;
@@ -2771,7 +2770,7 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     attr.value = (uintptr_t)&value;
     attr.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
-    REQUIRE(next_key == 100); // Check it returned the first key.
+    REQUIRE(next_key == first_key); // Check it returned the first key.
 
     Platform::_close(map_fd);
 }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2743,30 +2743,35 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) < 0);
     REQUIRE(errno == ENOENT);
 
-    // // Test that the bpf_map_get_next_key returns the first key of the BPF map if the previous key is not found.
-    // // Add 3 entries entry.
-    // for (key = 100; key < 400; key += 100) {
-    //     value = (uint64_t)key * 10;
-    //     memset(&attr, 0, sizeof(attr));
-    //     attr.map_fd = map_fd;
-    //     attr.key = (uintptr_t)&key;
-    //     attr.value = (uintptr_t)&value;
-    //     REQUIRE(bpf(BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr)) == 0);
-    // }
-    // // Start looping from the first key...
-    // memset(&attr, 0, sizeof(attr));
-    // attr.map_fd = map_fd;
-    // attr.key = 100;
-    // attr.next_key = (uintptr_t)&next_key;
-    // REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
-    // REQUIRE(value == attr.key * 10);
-    // // ...then lookup a key that is not present, and check that the first key is returned.
-    // memset(&attr, 0, sizeof(attr));
-    // attr.map_fd = map_fd;
-    // attr.key = 400;
-    // attr.next_key = (uintptr_t)&next_key;
-    // REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
-    // REQUIRE(value == 100 * 10); // Check it returned the first key.
+    // Test that the bpf_map_get_next_key returns the first key of the BPF map if the previous key is not found.
+    // Add 3 entries entry.
+    for (key = 100; key < 400; key += 100) {
+        value = (uint64_t)key * 10;
+        memset(&attr, 0, sizeof(attr));
+        attr.map_fd = map_fd;
+        attr.key = (uintptr_t)&key;
+        attr.value = (uintptr_t)&value;
+        REQUIRE(bpf(BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr)) == 0);
+    }
+    // Start looping from the first key...
+    key = 100;
+    value = 0;
+    memset(&attr, 0, sizeof(attr));
+    attr.map_fd = map_fd;
+    attr.key = (uintptr_t)&key;
+    attr.value = (uintptr_t)&value;
+    REQUIRE(bpf(BPF_MAP_LOOKUP_ELEM, &attr, sizeof(attr)) == 0);
+    REQUIRE(value == attr.key * 10);
+    // ...then lookup a key that is not present, and check that the first key is returned.
+    key = 400;
+    value = 0;
+    memset(&attr, 0, sizeof(attr));
+    attr.map_fd = map_fd;
+    attr.key = (uintptr_t)&key;
+    attr.value = (uintptr_t)&value;
+    attr.next_key = (uintptr_t)&next_key;
+    REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
+    REQUIRE(value == 100 * 10); // Check it returned the first key.
 
     Platform::_close(map_fd);
 }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2759,7 +2759,8 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     attr.map_fd = map_fd;
     attr.key = NULL;
     attr.value = (uintptr_t)&value;
-    REQUIRE(bpf(BPF_MAP_LOOKUP_ELEM, &attr, sizeof(attr)) == 0);
+    attr.next_key = (uintptr_t)&next_key;
+    REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
     uint64_t first_key = attr.next_key;
     // ...then lookup a key that is not present, and check that the first key is returned.
     key = 400;

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -2761,7 +2761,7 @@ TEST_CASE("BPF_MAP_GET_NEXT_KEY etc.", "[libbpf]")
     attr.value = (uintptr_t)&value;
     attr.next_key = (uintptr_t)&next_key;
     REQUIRE(bpf(BPF_MAP_GET_NEXT_KEY, &attr, sizeof(attr)) == 0);
-    uint64_t first_key = attr.next_key;
+    uint64_t first_key = next_key;
     // ...then lookup a key that is not present, and check that the first key is returned.
     key = 400;
     value = 0;


### PR DESCRIPTION
Closes 2942

## Description

This PR fixes the behavior of `bpf_map_get_next_key` specifically to the following (as per the official documentation here: https://man7.org/linux/man-pages/man2/bpf.2.html):

*(...) If key is not found, the operation returns zero and sets the next_key pointer to the key of the first element. (...)*

## Testing

CI/CD

## Documentation

n.a.

## Installation

n.a.
